### PR TITLE
Issue 22: Delete constraints on attachment size

### DIFF
--- a/samples/fragment-business.js
+++ b/samples/fragment-business.js
@@ -16,8 +16,6 @@
   allowAttachments: true,
   attachmentConstraints: {
     maximumAttachmentCount: 1,
-    maximumTotalSize: 2097664,
-    maximumIndividualSize: 512,
     supportedExtensions: [ 'txt' ],
     supportedContentTypes: [ 'text/plain' ],
     requireAttachmentReferences: true

--- a/src/testing/validation-error-formatter.js
+++ b/src/testing/validation-error-formatter.js
@@ -92,15 +92,6 @@ exports.maximumAttachmentCountViolation =
   (maxCount) => `documents of this type must not have more than ${maxCount} attachments`;
 
 /**
- * Formats a message for the error that occurs when a document's attachment exceeds the maximum individual attachment size.
- *
- * @param {string} attachmentName The name of the attachment in question
- * @param {integer} maxSize The maximum size, in bytes, that is allowed
- */
-exports.maximumIndividualAttachmentSizeViolation =
-  (attachmentName, maxSize) => `attachment ${attachmentName} must not exceed ${maxSize} bytes`;
-
-/**
  * Formats a message for the error that occurs when a string or array's length is greater than the maximum allowed.
  *
  * @param {string} itemPath The full path of the property or element in which the error occurs (e.g. "objectProp.arrayProp[2].stringProp")
@@ -118,14 +109,6 @@ exports.maximumLengthViolation =
  */
 exports.maximumSizeAttachmentViolation =
   (itemPath, maxSize) => `attachment reference "${itemPath}" must not be larger than ${maxSize} bytes`;
-
-/**
- * Formats a message for the error that occurs when a document's attachments exceed the maximum total attachment size.
- *
- * @param {integer} maxSize The maximum size, in bytes, that is allowed
- */
-exports.maximumTotalAttachmentSizeViolation =
-  (maxSize) => `documents of this type must not have a combined attachment size greater than ${maxSize} bytes`;
 
 /**
  * Formats a message for the error that occurs when a value is greater than the maximum allowed.

--- a/src/testing/validation-error-formatter.spec.js
+++ b/src/testing/validation-error-formatter.spec.js
@@ -31,19 +31,6 @@ describe('Validation error formatter', () => {
         .to.equal(`documents of this type must not have more than ${maximumAttachmentCount} attachments`);
     });
 
-    it('produces attachments maximumIndividualSize violation messages', () => {
-      const fileName = 'my-attachment-file.jpg';
-      const maximumAttachmentSize = 2;
-      expect(errorFormatter.maximumIndividualAttachmentSizeViolation(fileName, maximumAttachmentSize))
-        .to.equal(`attachment ${fileName} must not exceed ${maximumAttachmentSize} bytes`);
-    });
-
-    it('produces attachments maximumTotalSize violation messages', () => {
-      const maximumSize = 2;
-      expect(errorFormatter.maximumTotalAttachmentSizeViolation(maximumSize))
-        .to.equal(`documents of this type must not have a combined attachment size greater than ${maximumSize} bytes`);
-    });
-
     it('produces requireAttachmentReferences violation messages', () => {
       const fileName = 'my-attachment-file.txt';
       expect(errorFormatter.requireAttachmentReferencesViolation(fileName))

--- a/src/validation/document-definition-schema.js
+++ b/src/validation/document-definition-schema.js
@@ -38,16 +38,6 @@ module.exports = exports = joi.object().options({ convert: false }).keys({
       {
         requireAttachmentReferences: dynamicConstraintSchema(joi.boolean()),
         maximumAttachmentCount: dynamicConstraintSchema(integerSchema.min(1)),
-        maximumIndividualSize: dynamicConstraintSchema(integerSchema.min(1)),
-        maximumTotalSize: dynamicConstraintSchema(
-          integerSchema.when(
-            // This property must be greater or equal to "maximumIndividualSize" if it's defined
-            'maximumIndividualSize',
-            {
-              is: integerSchema.exist(),
-              then: integerSchema.min(joi.ref('maximumIndividualSize')),
-              otherwise: integerSchema.min(1)
-            })),
         supportedExtensions: dynamicConstraintSchema(joi.array().min(1).items(joi.string())),
         supportedContentTypes: dynamicConstraintSchema(joi.array().min(1).items(nonEmptyStringSchema))
       })),

--- a/src/validation/document-definitions-validator.spec.js
+++ b/src/validation/document-definitions-validator.spec.js
@@ -62,8 +62,6 @@ describe('Document definitions validator:', () => {
           allowAttachments: false, // Must be true since "attachmentConstraints" is defined
           attachmentConstraints: {
             maximumAttachmentCount: 0, // Must be at least 1
-            maximumIndividualSize: -1500, // Must be a positive number
-            maximumTotalSize: -1501, // Must be greater or equal to "maximumIndividualSize"
             supportedExtensions: (doc, oldDoc, extraParam) => [ extraParam ], // Has too many params
             supportedContentTypes: [ ] // Must have at least one element
           },
@@ -213,8 +211,6 @@ describe('Document definitions validator:', () => {
         'myDoc1.immutable: \"immutable\" conflict with forbidden peer \"cannotReplace\"',
         'myDoc1.allowAttachments: \"allowAttachments\" must be one of [true]',
         'myDoc1.attachmentConstraints.maximumAttachmentCount: \"maximumAttachmentCount\" must be larger than or equal to 1',
-        'myDoc1.attachmentConstraints.maximumIndividualSize: \"maximumIndividualSize\" must be larger than or equal to 1',
-        'myDoc1.attachmentConstraints.maximumTotalSize: \"maximumTotalSize\" must be larger than or equal to -1500',
         'myDoc1.attachmentConstraints.supportedExtensions: "supportedExtensions" must have an arity lesser or equal to 2',
         'myDoc1.attachmentConstraints.supportedContentTypes: \"supportedContentTypes\" must contain at least 1 items',
         'myDoc1.customActions: \"customActions\" must have at least 1 children',

--- a/templates/validation-function/attachments-validation-module.js
+++ b/templates/validation-function/attachments-validation-module.js
@@ -53,10 +53,6 @@ function attachmentsValidationModule(utils, buildItemPath, resolveItemConstraint
 
     var maximumAttachmentCount =
       attachmentConstraints ? utils.resolveDocumentConstraint(attachmentConstraints.maximumAttachmentCount) : null;
-    var maximumIndividualAttachmentSize =
-      attachmentConstraints ? utils.resolveDocumentConstraint(attachmentConstraints.maximumIndividualSize) : null;
-    var maximumTotalAttachmentSize =
-      attachmentConstraints ? utils.resolveDocumentConstraint(attachmentConstraints.maximumTotalSize) : null;
 
     var supportedExtensions =
       attachmentConstraints ? utils.resolveDocumentConstraint(attachmentConstraints.supportedExtensions) : null;
@@ -84,13 +80,6 @@ function attachmentsValidationModule(utils, buildItemPath, resolveItemConstraint
         validationErrors.push('attachment ' + attachmentName + ' must have a corresponding attachment reference property');
       }
 
-      if (utils.isValueAnInteger(maximumIndividualAttachmentSize) && attachmentSize > maximumIndividualAttachmentSize) {
-        // If this attachment is owned by an attachment reference property, that property's size constraint (if any) takes precedence
-        if (utils.isValueNullOrUndefined(attachmentRefValidator) || !utils.isValueAnInteger(attachmentRefValidator.maximumSize)) {
-          validationErrors.push('attachment ' + attachmentName + ' must not exceed ' + maximumIndividualAttachmentSize + ' bytes');
-        }
-      }
-
       if (supportedExtensionsRegex && !supportedExtensionsRegex.test(attachmentName)) {
         // If this attachment is owned by an attachment reference property, that property's extensions constraint (if any) takes
         // precedence
@@ -108,10 +97,6 @@ function attachmentsValidationModule(utils, buildItemPath, resolveItemConstraint
           validationErrors.push('attachment "' + attachmentName + '" must have a supported content type (' + supportedContentTypes.join(',') + ')');
         }
       }
-    }
-
-    if (utils.isValueAnInteger(maximumTotalAttachmentSize) && totalSize > maximumTotalAttachmentSize) {
-      validationErrors.push('documents of this type must not have a combined attachment size greater than ' + maximumTotalAttachmentSize + ' bytes');
     }
 
     if (utils.isValueAnInteger(maximumAttachmentCount) && attachmentCount > maximumAttachmentCount) {

--- a/test/attachment-constraints.spec.js
+++ b/test/attachment-constraints.spec.js
@@ -55,58 +55,6 @@ describe('File attachment constraints:', () => {
         testFixture.verifyDocumentReplaced(doc, oldDoc);
       });
 
-      describe('maximum attachment size constraints', () => {
-        it('should block creation of a document whose attachments exceed the limits', () => {
-          const doc = {
-            _id: 'myDoc',
-            _attachments: {
-              'foo.pdf': {
-                length: 5,
-                content_type: 'application/pdf'
-              },
-              'bar.html': {
-                length: 35,
-                content_type: 'text/html'
-              },
-              'baz.txt': {
-                length: 1,
-                content_type: 'text/plain'
-              }
-            },
-            type: 'staticRegularAttachmentsDoc',
-            attachmentRefProp: 'bar.html' // The attachmentReference's maximum size of 40 overrides the document's maximum individual size of 25
-          };
-
-          testFixture.verifyDocumentNotCreated(doc, 'staticRegularAttachmentsDoc', errorFormatter.maximumTotalAttachmentSizeViolation(40));
-        });
-
-        it('should block replacement when document attachments exceed the limits', () => {
-          const doc = {
-            _id: 'myDoc',
-            _attachments: {
-              'foo.xml': {
-                length: 41,
-                content_type: 'application/xml'
-              }
-            },
-            type: 'staticRegularAttachmentsDoc'
-          };
-          const oldDoc = {
-            _id: 'myDoc',
-            type: 'staticRegularAttachmentsDoc'
-          };
-
-          testFixture.verifyDocumentNotReplaced(
-            doc,
-            oldDoc,
-            'staticRegularAttachmentsDoc',
-            [
-              errorFormatter.maximumTotalAttachmentSizeViolation(40),
-              errorFormatter.maximumIndividualAttachmentSizeViolation('foo.xml', 25)
-            ]);
-        });
-      });
-
       describe('maximum attachment count constraint', () => {
         it('should block creation of a document whose attachments exceed the limit', () => {
           const doc = {
@@ -404,8 +352,6 @@ describe('File attachment constraints:', () => {
         },
         type: 'dynamicAttachmentsDoc',
         attachmentsEnabled: true,
-        maximumIndividualSize: 20,
-        maximumTotalSize: 40,
         maximumAttachmentCount: 3,
         supportedExtensions: [ 'pdf', 'html', 'foo' ],
         supportedContentTypes: [ 'application/pdf', 'text/html', 'text/bar' ],
@@ -437,8 +383,6 @@ describe('File attachment constraints:', () => {
         },
         type: 'dynamicAttachmentsDoc',
         attachmentsEnabled: true,
-        maximumIndividualSize: 15,
-        maximumTotalSize: 30,
         maximumAttachmentCount: 2,
         supportedExtensions,
         supportedContentTypes,
@@ -451,8 +395,6 @@ describe('File attachment constraints:', () => {
         'dynamicAttachmentsDoc',
         [
           errorFormatter.requireAttachmentReferencesViolation('baz.foo'),
-          errorFormatter.maximumIndividualAttachmentSizeViolation('foo.pdf', 15),
-          errorFormatter.maximumTotalAttachmentSizeViolation(30),
           errorFormatter.maximumAttachmentCountViolation(2),
           errorFormatter.supportedExtensionsRawAttachmentViolation('bar.html', supportedExtensions),
           errorFormatter.supportedContentTypesRawAttachmentViolation('baz.foo', supportedContentTypes)

--- a/test/resources/attachment-constraints-doc-definitions.js
+++ b/test/resources/attachment-constraints-doc-definitions.js
@@ -4,8 +4,6 @@
     authorizedRoles: { write: 'write' },
     allowAttachments: true,
     attachmentConstraints: {
-      maximumIndividualSize: 25,
-      maximumTotalSize: 40,
       maximumAttachmentCount: 3,
       supportedExtensions: [ 'html', 'jpg', 'pdf', 'txt', 'xml' ],
       supportedContentTypes: [ 'text/html', 'image/jpeg', 'application/pdf', 'text/plain', 'application/xml' ]
@@ -40,12 +38,6 @@
     },
     attachmentConstraints: function(doc, oldDoc) {
       return {
-        maximumIndividualSize: function(doc, oldDoc) {
-          return doc.maximumIndividualSize;
-        },
-        maximumTotalSize: function(doc, oldDoc) {
-          return doc.maximumTotalSize;
-        },
         maximumAttachmentCount: function(doc, oldDoc) {
           return doc.maximumAttachmentCount;
         },
@@ -63,12 +55,6 @@
     propertyValidators: {
       attachmentsEnabled: {
         type: 'boolean'
-      },
-      maximumIndividualSize: {
-        type: 'integer'
-      },
-      maximumTotalSize: {
-        type: 'integer'
       },
       maximumAttachmentCount: {
         type: 'integer'

--- a/test/sample-business.spec.js
+++ b/test/sample-business.spec.js
@@ -107,8 +107,6 @@ describe('Sample Business config doc definition', () => {
         errorFormatter.supportedExtensionsAttachmentReferenceViolation('businessLogoAttachment', [ 'png', 'gif', 'jpg', 'jpeg' ]),
         errorFormatter.supportedContentTypesAttachmentReferenceViolation('businessLogoAttachment', [ 'image/png', 'image/gif', 'image/jpeg' ]),
         errorFormatter.maximumSizeAttachmentViolation('businessLogoAttachment', 2097152),
-        errorFormatter.maximumTotalAttachmentSizeViolation(2097664),
-        errorFormatter.maximumIndividualAttachmentSizeViolation('invalid.xml', 512),
         errorFormatter.maximumAttachmentCountViolation(1),
         errorFormatter.supportedExtensionsRawAttachmentViolation('invalid.xml', [ 'txt' ]),
         errorFormatter.supportedContentTypesRawAttachmentViolation('invalid.xml', [ 'text/plain' ]),


### PR DESCRIPTION
# Description

The constraints cannot be enforced reliably, so they have been removed entirely. See the related issue for more info.

# Testing

```bash
npm test
```

# Related Issue

* GitHub issue link: #22