### PR TITLE
Issue #38: Implementation of conditional validation type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 ### Added
 - [#33](https://github.com/OldSneerJaw/couchster/issues/33): Option to ignore item validation errors when value is unchanged
 - [#34](https://github.com/OldSneerJaw/couchster/issues/34): Validation type that accepts any type of value
+- [#38](https://github.com/OldSneerJaw/couchster/issues/38): Conditional validation type
 
 ## [1.1.0] - 2018-06-04
 ### Added

--- a/samples/fragment-notification.js
+++ b/samples/fragment-notification.js
@@ -86,22 +86,42 @@
       type: 'array',
       immutable: true,
       arrayElementsValidator: {
-        type: 'object',
+        type: 'conditional',
         required: true,
-        propertyValidators: {
-          url: {
-            // The URL of the action
-            type: 'string',
-            required: true,
-            mustNotBeEmpty: true
+        validationCandidates: [
+          {
+            condition: function(doc, oldDoc, currentItemEntry, validationItemStack) {
+              return typeof currentItemEntry.itemValue === 'object';
+            },
+            validator: {
+              type: 'object',
+              propertyValidators: {
+                url: {
+                  // The URL of the action
+                  type: 'string',
+                  required: true,
+                  mustNotBeEmpty: true
+                },
+                label: {
+                  // A plain text label for the action
+                  type: 'string',
+                  required: true,
+                  mustNotBeEmpty: true
+                }
+              }
+            }
           },
-          label: {
-            // A plain text label for the action
-            type: 'string',
-            required: true,
-            mustNotBeEmpty: true
+          {
+            condition: function(doc, oldDoc, currentItemEntry, validationItemStack) {
+              return typeof currentItemEntry.itemValue === 'string';
+            },
+            validator: {
+              // The URL of the action
+              type: 'string',
+              mustNotBeEmpty: true
+            }
           }
-        }
+        ]
       }
     }
   }

--- a/samples/fragment-notifications-config.js
+++ b/samples/fragment-notifications-config.js
@@ -21,16 +21,36 @@
             // The list of notification transports that are enabled for the notification type
             type: 'array',
             arrayElementsValidator: {
-              type: 'object',
+              type: 'conditional',
               required: true,
-              propertyValidators: {
-                transportId: {
-                  // The ID of the notification transport
-                  type: 'string',
-                  required: true,
-                  mustNotBeEmpty: true
+              validationCandidates: [
+                {
+                  condition: function(doc, oldDoc, currentItemEntry, validationItemStack) {
+                    return typeof currentItemEntry.itemValue === 'object';
+                  },
+                  validator: {
+                    type: 'object',
+                    propertyValidators: {
+                      transportId: {
+                        // The ID of the notification transport
+                        type: 'string',
+                        required: true,
+                        mustNotBeEmpty: true
+                      }
+                    }
+                  }
+                },
+                {
+                  condition: function(doc, oldDoc, currentItemEntry, validationItemStack) {
+                    return typeof currentItemEntry.itemValue === 'string';
+                  },
+                  validator: {
+                    // The ID of the notification transport
+                    type: 'string',
+                    mustNotBeEmpty: true
+                  }
                 }
-              }
+              ]
             }
           }
         }

--- a/src/testing/validation-error-formatter.js
+++ b/src/testing/validation-error-formatter.js
@@ -352,6 +352,15 @@ exports.unsupportedProperty = (propertyPath) => `property "${propertyPath}" is n
  */
 exports.uuidFormatInvalid = (itemPath) => `item "${itemPath}" must be ${getTypeDescription('uuid')}`;
 
+/**
+ * Formats a message for the error that occurs when a value does not satisfy any of the candidate validators for
+ * conditional validation.
+ *
+ * @param {string} itemPath The full path of the property or element in which the error occurs (e.g. "hashtableProp[my-key]")
+ */
+exports.validationConditionsViolation =
+  (itemPath) => `item "${itemPath}" does not satisfy any candidate validation conditions`;
+
 function getTypeDescription(type) {
   switch (type) {
     case 'array':

--- a/src/testing/validation-error-formatter.spec.js
+++ b/src/testing/validation-error-formatter.spec.js
@@ -226,6 +226,11 @@ describe('Validation error formatter', () => {
       expect(errorFormatter.uuidFormatInvalid(fakeItemPath)).to.equal(`item "${fakeItemPath}" must be a UUID string`);
     });
 
+    it('produces validation conditions violation messages', () => {
+      expect(errorFormatter.validationConditionsViolation(fakeItemPath))
+        .to.equal(`item "${fakeItemPath}" does not satisfy any candidate validation conditions`);
+    });
+
     describe('type constraint violations', () => {
       it('formats messages for general types', () => {
         const typeDescriptions = {

--- a/src/validation/document-definitions-validator.spec.js
+++ b/src/validation/document-definitions-validator.spec.js
@@ -68,6 +68,32 @@ describe('Document definitions validator:', () => {
           },
           customActions: { }, // Must have at least one property
           propertyValidators: {
+            conditionalTypeProperty: {
+              type: 'conditional',
+              immutableWhenSetStrict: true,
+              minimumValue: -15, // Unsupported constraint for this validation type
+              validationCandidates: [
+                {
+                  condition: (a, b, c, d, extra) => extra, // Too many parameters and must have a "validator" property
+                  foobar: 'baz' // Unsupported property
+                },
+                {
+                  condition: true, // Must be a function
+                  validator: {
+                    type: 'float',
+                    maximumLength: 3, // Unsupported constraint for this validation type
+                    mustEqual: (a, b, c, d) => d
+                  }
+                },
+                {
+                  condition: () => true,
+                  validator: {
+                    type: 'object',
+                    allowUnknownProperties: 0 // Must be a boolean
+                  }
+                }
+              ]
+            },
             timeProperty: {
               type: 'time',
               immutable: 1, // Must be a boolean
@@ -228,6 +254,13 @@ describe('Document definitions validator:', () => {
         'myDoc1.attachmentConstraints.supportedContentTypes: \"supportedContentTypes\" must contain at least 1 items',
         'myDoc1.attachmentConstraints.filenameRegexPattern: \"filenameRegexPattern\" must be an instance of \"RegExp\"',
         'myDoc1.customActions: \"customActions\" must have at least 1 children',
+        'myDoc1.propertyValidators.conditionalTypeProperty.minimumValue: \"minimumValue\" is not allowed',
+        'myDoc1.propertyValidators.conditionalTypeProperty.validationCandidates.0.condition: \"condition\" must have an arity lesser or equal to 4',
+        'myDoc1.propertyValidators.conditionalTypeProperty.validationCandidates.0.foobar: \"foobar\" is not allowed',
+        'myDoc1.propertyValidators.conditionalTypeProperty.validationCandidates.0.validator: \"validator\" is required',
+        'myDoc1.propertyValidators.conditionalTypeProperty.validationCandidates.1.condition: \"condition\" must be a Function',
+        'myDoc1.propertyValidators.conditionalTypeProperty.validationCandidates.1.validator.maximumLength: \"maximumLength\" is not allowed',
+        'myDoc1.propertyValidators.conditionalTypeProperty.validationCandidates.2.validator.allowUnknownProperties: \"allowUnknownProperties\" must be a boolean',
         'myDoc1.propertyValidators.timeProperty.immutable: \"immutable\" must be a boolean',
         'myDoc1.propertyValidators.timeProperty.minimumValue: \"minimumValue\" with value \"15\" fails to match the required pattern: /^((([01]\\d|2[0-3])(:[0-5]\\d)(:[0-5]\\d(\\.\\d{1,3})?)?)|(24:00(:00(\\.0{1,3})?)?))$/',
         'myDoc1.propertyValidators.timeProperty.maximumValue: \"maximumValue\" with value \"23:49:52.1234\" fails to match the required pattern: /^((([01]\\d|2[0-3])(:[0-5]\\d)(:[0-5]\\d(\\.\\d{1,3})?)?)|(24:00(:00(\\.0{1,3})?)?))$/',
@@ -286,7 +319,7 @@ describe('Document definitions validator:', () => {
         'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.arrayElementsValidator.propertyValidators.anyProperty.minimumValue: \"minimumValue\" is not allowed',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.arrayElementsValidator.propertyValidators.anyProperty.mustNotBeEmpty: \"mustNotBeEmpty\" is not allowed',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.arrayElementsValidator.propertyValidators.anyProperty.regexPattern: \"regexPattern\" is not allowed',
-        'myDoc1.propertyValidators.nestedObject.propertyValidators.unrecognizedTypeProperty.type: \"type\" must be one of [any, array, attachmentReference, boolean, date, datetime, enum, float, hashtable, integer, object, string, time, timezone, uuid]',
+        'myDoc1.propertyValidators.nestedObject.propertyValidators.unrecognizedTypeProperty.type: \"type\" must be one of [any, array, attachmentReference, boolean, conditional, date, datetime, enum, float, hashtable, integer, object, string, time, timezone, uuid]',
       ]);
   });
 });

--- a/templates/validation-function/document-properties-validation-module.js
+++ b/templates/validation-function/document-properties-validation-module.js
@@ -93,7 +93,9 @@ function documentPropertiesValidationModule(utils, simpleTypeFilter, typeIdValid
         var itemValue = currentItemEntry.itemValue;
         var validatorType = resolveItemConstraint(validator.type);
 
-        if (shouldSkipItemValidation(validator, validatorType)) {
+        if (validatorType === 'conditional') {
+          return performConditionalValidation(validator);
+        } else if (shouldSkipItemValidation(validator, validatorType)) {
           return;
         }
 
@@ -103,7 +105,7 @@ function documentPropertiesValidationModule(utils, simpleTypeFilter, typeIdValid
 
         if (!utils.isDocumentMissingOrDeleted(oldDoc)) {
           if (resolveItemConstraint(validator.immutable)) {
-            storeOptionalValidationErrors(comparisonModule.validateImmutable(itemStack, false, validator.type));
+            storeOptionalValidationErrors(comparisonModule.validateImmutable(itemStack, false, validatorType));
           }
 
           if (resolveItemConstraint(validator.immutableStrict)) {
@@ -113,7 +115,7 @@ function documentPropertiesValidationModule(utils, simpleTypeFilter, typeIdValid
           }
 
           if (resolveItemConstraint(validator.immutableWhenSet)) {
-            storeOptionalValidationErrors(comparisonModule.validateImmutable(itemStack, true, validator.type));
+            storeOptionalValidationErrors(comparisonModule.validateImmutable(itemStack, true, validatorType));
           }
 
           if (resolveItemConstraint(validator.immutableWhenSetStrict)) {
@@ -125,7 +127,7 @@ function documentPropertiesValidationModule(utils, simpleTypeFilter, typeIdValid
 
         var expectedEqualValue = resolveItemConstraint(validator.mustEqual);
         if (expectedEqualValue !== void 0) {
-          storeOptionalValidationErrors(comparisonModule.validateEquality(itemStack, expectedEqualValue, validator.type));
+          storeOptionalValidationErrors(comparisonModule.validateEquality(itemStack, expectedEqualValue, validatorType));
         }
 
         var expectedStrictEqualValue = resolveItemConstraint(validator.mustEqualStrict);
@@ -391,6 +393,41 @@ function documentPropertiesValidationModule(utils, simpleTypeFilter, typeIdValid
         }
       }
 
+      function performConditionalValidation(validator) {
+        var currentItemEntry = itemStack[itemStack.length - 1];
+
+        // Copy all but the last element so that the item's parent is at the top of the stack for condition functions
+        var conditionalValidationItemStack = itemStack.slice(0, -1);
+
+        var validationCandidates = resolveItemConstraint(validator.validationCandidates) || [ ];
+        for (var candidateIndex = 0; candidateIndex < validationCandidates.length; candidateIndex++) {
+          var candidate = validationCandidates[candidateIndex];
+          if (typeof candidate.condition === 'function' &&
+              candidate.condition(newDoc, oldDoc, currentItemEntry, conditionalValidationItemStack)) {
+
+            // Create a new validator that merges the universal constraints from the conditional validator and the more
+            // specific constraints from the candidate validator
+            var combinedValidator =
+              assignProperties({ }, [ validator, candidate.validator ], [ 'validationCandidates' ]);
+
+            return validateItemValue(combinedValidator);
+          }
+        }
+
+        // If we got here, then none of the candidate validator conditions were satisfied
+        if (shouldSkipItemValidation(validator, resolveItemConstraint('conditional'))) {
+          return;
+        } else if (utils.isValueNullOrUndefined(currentItemEntry.itemValue)) {
+          // Ensure that a null/missing value does not violate any of the universal constraints specified by the
+          // conditional validator (e.g. required, immutable)
+          var nullValidator = assignProperties({ }, [ validator, { type: 'any' } ], [ 'validationCandidates' ]);
+
+          validateItemValue(nullValidator);
+        } else {
+          validationErrors.push('item "' + buildItemPath(itemStack) + '" does not satisfy any candidate validation conditions');
+        }
+      }
+
       function performCustomValidation(validator) {
         var currentItemEntry = itemStack[itemStack.length - 1];
 
@@ -474,5 +511,19 @@ function documentPropertiesValidationModule(utils, simpleTypeFilter, typeIdValid
     }
 
     return nameComponents.join('');
+  }
+
+  function assignProperties(target, sources, skipPropertyNames) {
+    var actualSkipPropertyNames = skipPropertyNames || [ ];
+    for (var sourceIndex = 0; sourceIndex < sources.length; sourceIndex++) {
+      var source = sources[sourceIndex];
+      for (var propertyName in source) {
+        if (source.hasOwnProperty(propertyName) && actualSkipPropertyNames.indexOf(propertyName) < 0) {
+          target[propertyName] = source[propertyName];
+        }
+      }
+    }
+
+    return target;
   }
 }

--- a/test/conditional-validation.spec.js
+++ b/test/conditional-validation.spec.js
@@ -1,0 +1,417 @@
+const testFixtureMaker = require('../src/testing/test-fixture-maker');
+const errorFormatter = require('../src/testing/validation-error-formatter');
+
+describe('Conditional validation type:', () => {
+  const testFixture =
+    testFixtureMaker.initFromValidationFunction('build/validation-functions/test-conditional-validation-validation-function.js');
+
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
+  });
+
+  describe('with static validation', () => {
+    it('allows creation when a condition is satisifed and the contents are valid', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: 1534026439173
+        }
+      };
+
+      testFixture.verifyDocumentCreated(doc);
+    });
+
+    it('allows replacement when a condition is satisifed and the contents are valid', () => {
+      const oldDoc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: '2018-08-11T15:25:00.0-07:00'
+        }
+      };
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: '2018-08-11T15:25-07:00' // Semantically equal to the old value
+        }
+      };
+
+      testFixture.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('allows creation when no conditions are satisfied but the vale is null', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: null
+        }
+      };
+
+      testFixture.verifyDocumentCreated(doc);
+    });
+
+    it('allows replacement when no conditions are satisfied but the value is missing', () => {
+      const oldDoc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: null
+        }
+      };
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: { }
+      };
+
+      testFixture.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('allows replacement when no conditions are satisfied but the value is unchanged', () => {
+      const oldDoc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: { foo: 'bar' }
+        }
+      };
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: { foo: 'bar' }
+        }
+      };
+
+      testFixture.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('rejects creation when no conditions are satisfied', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: [ ]
+        }
+      };
+
+      testFixture.verifyDocumentNotCreated(
+        doc,
+        'conditionalValidationDoc',
+        [ errorFormatter.validationConditionsViolation('staticParentObjectProp.conditionalValidationProp') ]);
+    });
+
+    it('rejects replacement when no conditions are satisfied', () => {
+      const oldDoc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc'
+      };
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: true
+        }
+      };
+
+      testFixture.verifyDocumentNotReplaced(
+        doc,
+        oldDoc,
+        'conditionalValidationDoc',
+        [ errorFormatter.validationConditionsViolation('staticParentObjectProp.conditionalValidationProp') ]);
+    });
+
+    it('rejects creation when a condition is satisfied but an inner constraint is violated', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: '2018-08-10T16:59:59.999-07:00'
+        }
+      };
+
+      testFixture.verifyDocumentNotCreated(
+        doc,
+        'conditionalValidationDoc',
+        [
+          errorFormatter.minimumValueViolation(
+            'staticParentObjectProp.conditionalValidationProp',
+            '2018-08-10T24:00:00.000Z')
+        ]);
+    });
+
+    it('rejects replacement when a condition is satisfied but an inner constraint is violated', () => {
+      const oldDoc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: { }
+      };
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: 1533945599999
+        }
+      };
+
+      testFixture.verifyDocumentNotReplaced(
+        doc,
+        oldDoc,
+        'conditionalValidationDoc',
+        [ errorFormatter.minimumValueViolation('staticParentObjectProp.conditionalValidationProp', 1533945600000) ]);
+    });
+
+    it('allows replacement when a condition is satisfied and an inner constraint overrides an outer constraint', () => {
+      const oldDoc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: 1
+        }
+      };
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: 2533945600000
+        }
+      };
+
+      // The outer (conditional) validator specifies that the property is immutable, but that is overridden by the inner
+      // (datetime) validator
+      testFixture.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('rejects replacement when a condition is satisfied but an outer constraint is violated', () => {
+      const oldDoc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: '2018-08-11T20:11:33-07:00'
+        }
+      };
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: '2018-08-11T20:21:02.13-07:00'
+        }
+      };
+
+      testFixture.verifyDocumentNotReplaced(
+        doc,
+        oldDoc,
+        'conditionalValidationDoc',
+        [ errorFormatter.immutableItemViolation('staticParentObjectProp.conditionalValidationProp') ]);
+    });
+
+    it('rejects replacement when the condition specifies that the same validator must be used as for the old doc', () => {
+      const oldDoc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: 1534019296900
+        }
+      };
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        staticParentObjectProp: {
+          conditionalValidationProp: '2018-08-11T20:28:16.9-07:00'
+        }
+      };
+
+      testFixture.verifyDocumentNotReplaced(
+        doc,
+        oldDoc,
+        'conditionalValidationDoc',
+        [
+          errorFormatter.typeConstraintViolation('staticParentObjectProp.conditionalValidationProp', 'integer') ]);
+    });
+  });
+
+  describe('with dynamic validation', () => {
+    it('allows creation of a valid array when arrays are allowed', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        dynamicConfig: { excludeArrayValidator: false },
+        dynamicConditionalValidationProp: [ 53, 45.9 ]
+      };
+
+      testFixture.verifyDocumentCreated(doc);
+    });
+
+    it('allows creation of a valid object when objects are allowed', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        dynamicConfig: {
+          excludeObjectValidator: false,
+          excludeHashtableValidator: true
+        },
+        dynamicConditionalValidationProp: { stringProp: 'foobar' }
+      };
+
+      testFixture.verifyDocumentCreated(doc);
+    });
+
+    it('allows creation of a valid hashtable when hashtables are allowed', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        dynamicConfig: {
+          excludeObjectValidator: true,
+          excludeHashtableValidator: false
+        },
+        dynamicConditionalValidationProp: { 'foo-bar': '1a7072c4-116a-4552-865d-74a4206d7695' }
+      };
+
+      testFixture.verifyDocumentCreated(doc);
+    });
+
+    it('allows creation of a valid value with a dynamic validator', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        dynamicConfig: { dynamicConditionType: 'boolean' },
+        dynamicConditionalValidationProp: true
+      };
+
+      testFixture.verifyDocumentCreated(doc);
+    });
+
+    it('allows creation of an object because object comes before hashtable in the candidate list', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        dynamicConfig: {
+          excludeObjectValidator: false,
+          excludeHashtableValidator: false
+        },
+        dynamicConditionalValidationProp: { stringProp: 'barbaz' }
+      };
+
+      testFixture.verifyDocumentCreated(doc);
+    });
+
+    it('rejects creation of an array when arrays are NOT allowed', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        dynamicConfig: { excludeArrayValidator: true },
+        dynamicConditionalValidationProp: [ ]
+      };
+
+      testFixture.verifyDocumentNotCreated(
+        doc,
+        'conditionalValidationDoc',
+        [ errorFormatter.validationConditionsViolation('dynamicConditionalValidationProp') ]);
+    });
+
+    it('rejects creation of an object/hashtable when they are NOT allowed', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        dynamicConfig: {
+          excludeObjectValidator: true,
+          excludeHashtableValidator: true
+        },
+        dynamicConditionalValidationProp: { foo: 'bar' }
+      };
+
+      testFixture.verifyDocumentNotCreated(
+        doc,
+        'conditionalValidationDoc',
+        [ errorFormatter.validationConditionsViolation('dynamicConditionalValidationProp') ]);
+    });
+
+    it('rejects creation of an array when the value is invalid', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        dynamicConditionalValidationProp: [ ]
+      };
+
+      testFixture.verifyDocumentNotCreated(
+        doc,
+        'conditionalValidationDoc',
+        [ errorFormatter.mustNotBeEmptyViolation('dynamicConditionalValidationProp') ]);
+    });
+
+    it('rejects creation of an object when the value is invalid', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        dynamicConfig: {
+          excludeObjectValidator: false,
+          excludeHashtableValidator: true
+        },
+        dynamicConditionalValidationProp: {
+          stringProp: 2847
+        }
+      };
+
+      testFixture.verifyDocumentNotCreated(
+        doc,
+        'conditionalValidationDoc',
+        [ errorFormatter.typeConstraintViolation('dynamicConditionalValidationProp.stringProp', 'string') ]);
+    });
+
+    it('rejects creation of a hashtable when the value is invalid', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        dynamicConfig: {
+          excludeObjectValidator: true,
+          excludeHashtableValidator: false
+        },
+        dynamicConditionalValidationProp: {
+          'my-value': 'not-a-uuid'
+        }
+      };
+
+      testFixture.verifyDocumentNotCreated(
+        doc,
+        'conditionalValidationDoc',
+        [ errorFormatter.typeConstraintViolation('dynamicConditionalValidationProp[my-value]', 'uuid') ]);
+    });
+
+    it('rejects creation when the value does not match the type expected by the dynamic validator', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        dynamicConfig: { dynamicConditionType: 'boolean' },
+        dynamicConditionalValidationProp: 1
+      };
+
+      testFixture.verifyDocumentNotCreated(
+        doc,
+        'conditionalValidationDoc',
+        [ errorFormatter.validationConditionsViolation('dynamicConditionalValidationProp') ]);
+    });
+
+    it('rejects creation of a hashtable because object comes before hashtable in the candidate list', () => {
+      const doc = {
+        _id: 'my-doc',
+        type: 'conditionalValidationDoc',
+        dynamicConfig: {
+          excludeObjectValidator: false,
+          excludeHashtableValidator: false
+        },
+        dynamicConditionalValidationProp: { 'my-uuid': '6417e336-a9fc-4d2c-965b-6fb5a49a26f6' }
+      };
+
+      testFixture.verifyDocumentNotCreated(
+        doc,
+        'conditionalValidationDoc',
+        [
+          errorFormatter.requiredValueViolation('dynamicConditionalValidationProp.stringProp'),
+          errorFormatter.unsupportedProperty('dynamicConditionalValidationProp.my-uuid')
+        ]);
+    });
+  });
+});

--- a/test/resources/conditional-validation-doc-definitions.js
+++ b/test/resources/conditional-validation-doc-definitions.js
@@ -1,0 +1,130 @@
+function() {
+  return {
+    conditionalValidationDoc: {
+      typeFilter: simpleTypeFilter,
+      authorizedRoles: { write: 'write' },
+      propertyValidators: {
+        staticParentObjectProp: {
+          type: 'object',
+          propertyValidators: {
+            conditionalValidationProp: {
+              type: 'conditional',
+              immutableWhenSet: true,
+              skipValidationWhenValueUnchanged: true,
+              validationCandidates: [
+                {
+                  condition: function(doc, oldDoc, currentItemEntry, validationItemStack) {
+                    var useOldValue = oldDoc && !isValueNullOrUndefined(currentItemEntry.oldItemValue);
+                    var itemValue = useOldValue ? currentItemEntry.oldItemValue : currentItemEntry.itemValue;
+
+                    return typeof(itemValue) === 'string';
+                  },
+                  validator: {
+                    type: 'datetime',
+                    minimumValue: '2018-08-10T24:00:00.000Z'
+                  }
+                },
+                {
+                  condition: function(doc, oldDoc, currentItemEntry, validationItemStack) {
+                    var useOldValue = oldDoc && !isValueNullOrUndefined(currentItemEntry.oldItemValue);
+                    var itemValue = useOldValue ? currentItemEntry.oldItemValue : currentItemEntry.itemValue;
+
+                    return typeof(itemValue) === 'number';
+                  },
+                  validator: {
+                    type: 'integer',
+                    minimumValue: 1533945600000, // Equivalent to 2018-08-10T24:00:00.000Z
+                    immutableWhenSet: false // Overrides immutableWhenSet from the outer validator
+                  }
+                }
+              ]
+            }
+          }
+        },
+        dynamicConfig: {
+          type: 'object',
+          propertyValidators: {
+            excludeArrayValidator: {
+              type: 'boolean'
+            },
+            excludeObjectValidator: {
+              type: 'boolean'
+            },
+            excludeHashtableValidator: {
+              type: 'boolean'
+            },
+            dynamicConditionType: {
+              type: 'string'
+            }
+          }
+        },
+        dynamicConditionalValidationProp: {
+          type: 'conditional',
+          validationCandidates: function(doc, oldDoc, value, oldValue) {
+            var candidates = [ ];
+
+            var config = doc.dynamicConfig || { };
+
+            if (!config.excludeArrayValidator) {
+              candidates.push({
+                condition: function(doc, oldDoc, currentItemEntry, validationItemStack) {
+                  return Array.isArray(currentItemEntry.itemValue);
+                },
+                validator: {
+                  type: 'array',
+                  mustNotBeEmpty: true,
+                  arrayElementsValidator: {
+                    type: 'float'
+                  }
+                }
+              });
+            }
+            if (!config.excludeObjectValidator) {
+              candidates.push({
+                condition: function(doc, oldDoc, currentItemEntry, validationItemStack) {
+                  return typeof currentItemEntry.itemValue === 'object' && !Array.isArray(currentItemEntry.itemValue);
+                },
+                validator: {
+                  type: 'object',
+                  propertyValidators: {
+                    stringProp: {
+                      type: 'string',
+                      required: true
+                    }
+                  }
+                }
+              });
+            }
+            if (!config.excludeHashtableValidator) {
+              candidates.push({
+                condition: function(doc, oldDoc, currentItemEntry, validationItemStack) {
+                  return typeof currentItemEntry.itemValue === 'object' && !Array.isArray(currentItemEntry.itemValue);
+                },
+                validator: {
+                  type: 'hashtable',
+                  hashtableValuesValidator: {
+                    type: 'uuid'
+                  }
+                }
+              });
+            }
+            if (config.dynamicConditionType) {
+              candidates.push({
+                condition: function(doc, oldDoc, currentItemEntry, validationItemStack) {
+                  var type = validationItemStack[0].itemValue.dynamicConfig.dynamicConditionType;
+
+                  return typeof(currentItemEntry.itemValue) === type;
+                },
+                validator: {
+                  type: config.dynamicConditionType
+                }
+              });
+            }
+
+            return candidates;
+          }
+        }
+      }
+    }
+  };
+}

--- a/test/sample-notification.spec.js
+++ b/test/sample-notification.spec.js
@@ -57,7 +57,7 @@ describe('Sample business notification doc definition', () => {
       subject: 'pay up!',
       message: 'you best pay up now, or else...',
       createdAt: '2016-02-29T17:13:43.666Z',
-      actions: [ { url: 'http://foobar.baz', label: 'pay up here'} ],
+      actions: [ 'http://foobar.baz', 'http://bazbar.foo' ],
       users: [ 'foobar', 'baz' ]
     };
 

--- a/test/sample-notifications-config.spec.js
+++ b/test/sample-notifications-config.spec.js
@@ -21,7 +21,9 @@ describe('Sample business notifications config doc definition', () => {
         invoicePayments: {
           enabledTransports: [
             { transportId: 'ET1' },
-            { transportId: 'ET2' }
+            { transportId: 'ET2' },
+            'ET3',
+            'ET4'
           ]
         }
       }
@@ -37,7 +39,8 @@ describe('Sample business notifications config doc definition', () => {
         invoicePayments: {
           enabledTransports: [
             { 'invalid-property': 'blah' },
-            { transportId: '' }
+            { transportId: '' },
+            ''
           ]
         },
         'Invalid-Type': {
@@ -57,6 +60,7 @@ describe('Sample business notifications config doc definition', () => {
         errorFormatter.unsupportedProperty('notificationTypes[invoicePayments].enabledTransports[0].invalid-property'),
         errorFormatter.requiredValueViolation('notificationTypes[invoicePayments].enabledTransports[0].transportId'),
         errorFormatter.mustNotBeEmptyViolation('notificationTypes[invoicePayments].enabledTransports[1].transportId'),
+        errorFormatter.mustNotBeEmptyViolation('notificationTypes[invoicePayments].enabledTransports[2]'),
         errorFormatter.regexPatternHashtableKeyViolation('notificationTypes[Invalid-Type]', /^[a-zA-Z]+$/),
         errorFormatter.hashtableKeyEmpty('notificationTypes'),
         errorFormatter.regexPatternHashtableKeyViolation('notificationTypes[]', /^[a-zA-Z]+$/),


### PR DESCRIPTION
# Description

The `conditional` validation type allows an item's value to conform to any one of several candidate validators. Each validator is accompanied by a condition that specifies whether to apply the validator to the item's value. If none of the conditions are satisfied, the value is rejected. This allows, for example, an array to contain a mix of data types or an object property to expect a different string format based on the state of other properties of the object.

# Testing

1. Generate a validation function from `conditional-validation-doc-definitions.js`:

```bash
./make-validation-function -j test/resources/conditional-validation-doc-definitions.js build/test-validation-function.js
```

2. Copy and paste the generated validation function into a CouchDB design document.
3. Attempt to create a document where neither condition is satisfied. Should be rejected with 403 Forbidden.

```
PUT /test/conditional-test-1 HTTP/1.1
Host: localhost:5984
Content-Type: application/json
Authorization: Basic ********

{
	"type": "conditionalValidationDoc",
	"staticParentObjectProp": {
		"conditionalValidationProp": false
	}
}
```

4. Attempt to create a document where the first condition is satisfied (the value is a string) but it fails validation (the string is not a datetime). Should be rejected with 403 Forbidden.

```
PUT /test/conditional-test-1 HTTP/1.1
Host: localhost:5984
Content-Type: application/json
Authorization: Basic ********

{
	"type": "conditionalValidationDoc",
	"staticParentObjectProp": {
		"conditionalValidationProp": "not-a-datetime"
	}
}
```

5. Attempt to create a document where the second condition is satisfied (the value is a number) but it fails validation (the number is not an integer and the number is less than the minimum value: 1533945600000). Should be rejected with 403 Forbidden.

```
PUT /test/conditional-test-1 HTTP/1.1
Host: localhost:5984
Content-Type: application/json
Authorization: Basic ********

{
	"type": "conditionalValidationDoc",
	"staticParentObjectProp": {
		"conditionalValidationProp": 52.5
	}
}
```

6. Create a document where the first condition is satisfied (the value is a string) with a valid datetime. Should be accepted with 201 Created.

```
PUT /test/conditional-test-1 HTTP/1.1
Host: localhost:5984
Content-Type: application/json
Authorization: Basic ********

{
	"type": "conditionalValidationDoc",
	"staticParentObjectProp": {
		"conditionalValidationProp": "2018-08-15T20:58:37-07:00"
	}
}
```

7. Attempt to replace the document with a value that is a valid integer but stills fails validation because the first condition is satisfied (i.e. the validator expects a datetime string but the value is a number) and the surrounding conditional validator specifies that it is immutable. Should be rejected with 403 Forbidden.

```
PUT /test/conditional-test-1?rev=1-17078bd3c567c8f3b19944aa5577aa67 HTTP/1.1
Host: localhost:5984
Content-Type: application/json
Authorization: Basic ********

{
	"type": "conditionalValidationDoc",
	"staticParentObjectProp": {
		"conditionalValidationProp": 1533945600000
	}
}
```

# Related Issue

* GitHub issue link: #38