### PR TITLE
Issue 43: Address lodash security vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 ### Fixed
 - [#46](https://github.com/OldSneerJaw/couchster/issues/46): Broken error equality test in Node.js 12
 
+### Security
+- [#43](https://github.com/OldSneerJaw/couchster/issues/43): Security vulnerability in lodash dev dependency
+
 ## [1.2.0] - 2018-09-06
 ### Added
 - [#33](https://github.com/OldSneerJaw/couchster/issues/33): Option to ignore item validation errors when value is unchanged

--- a/package-lock.json
+++ b/package-lock.json
@@ -2109,9 +2109,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "lodash.flattendeep": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "jshint": "^2.9.6",
+    "lodash": "^4.17.11",
     "mocha": "^6.0.0",
     "mock-require": "^3.0.2",
     "nyc": "^14.1.1"


### PR DESCRIPTION
# Description

There is a minor security vulnerability in lodash 4.17.10 and earlier, which is a transitive development dependency of synctos. Explicitly added lodash to the list of development dependencies and set its minimum version to 4.17.11.

# Testing

Since the change is NOT in a transitive dependency, simply reinstall dependencies with `npm install` and then run the full test suite with `npm test`.

# Related Issue

* GitHub issue link: #43