### PR TITLE
Automatic dependency update cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 10
     versioning-strategy: increase
 
   # GitHub Actions used in workflows
@@ -13,3 +15,5 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 10


### PR DESCRIPTION
Configures Dependabot to introduce dependency updates only after a new dependency version is at least 10 days old.